### PR TITLE
Update the deprecated http.createClient and other

### DIFF
--- a/lib/calais.js
+++ b/lib/calais.js
@@ -137,7 +137,7 @@ Calais.prototype = {
           }
         });
       }).on('error', function(e) {
-        console.log('Problem with the Open Calais Request (' + e.message + ')');
+        return callback('Problem with the Open Calais Request (' + e.message + ')');
       });
       req.end(this.options.content);
 


### PR DESCRIPTION
Hi,

I updated the library a bit to use the new http.request and also I added a control to response when the response.statusCode is 200. It was failing when Open Calais server was busy and responding with 403 or 500 or others.

Harry
